### PR TITLE
Fixes #1740 Enable Basic Auth and check for 401 after access request with token 

### DIFF
--- a/docker-auth.go
+++ b/docker-auth.go
@@ -41,8 +41,9 @@ func (d *DockerAuth) normalizeRepo(repository string) (string, error) {
 }
 
 //CheckAccess takes a repository and tries to get a JWT token from a docker registry 2 provider, if it succeeds in getting the token, we return true. If there is a failure grabbing the token, we return false and an error explaning what went wrong.
-//CheckAccess uses the following flow to get the token: https://docs.docker.com/registry/spec/auth/jwt/A
-//Meaning, it tries to make a call with basic auth parameters, and if that doesn't work it tries to request a token from the challenge in the Www-Authenticate header.
+//CheckAccess uses the following flow to get the token: https://docs.docker.com/registry/spec/auth/jwt
+//Meaning, it first makes a call without any authentication/authorization parameters to check if the registry
+//requires any authentication at all, and if that doesn't work it tries to request a token from the challenge in the Www-Authenticate header.
 func (d *DockerAuth) CheckAccess(repository string, scope Scope) (bool, error) {
 	httpClient := http.DefaultClient
 
@@ -55,7 +56,6 @@ func (d *DockerAuth) CheckAccess(repository string, scope Scope) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	d.authenticate(req)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return false, err

--- a/docker-auth.go
+++ b/docker-auth.go
@@ -55,7 +55,7 @@ func (d *DockerAuth) CheckAccess(repository string, scope Scope) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
+	d.authenticate(req)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return false, err
@@ -101,13 +101,16 @@ func (d *DockerAuth) CheckAccess(repository string, scope Scope) (bool, error) {
 			return false, err
 		}
 		defer resp.Body.Close()
-		statusCode := resp.StatusCode
-		if statusCode == 200 || statusCode == 202 {
+		if resp.StatusCode == 200 || resp.StatusCode == 202 {
 			return true, nil
 		}
 
 		if resp.StatusCode == 404 {
 			return false, ErrRepoNotFound
+		}
+
+		if resp.StatusCode == 401 {
+			return false, ErrRepoNotAuthorized
 		}
 	}
 	// if the remote server gives us the go ahead, we're fine

--- a/errors.go
+++ b/errors.go
@@ -7,3 +7,6 @@ var ErrUnexpectedResponse = errors.New("Unexpected Response")
 
 //ErrRepoNotFound is the error thrown when we were unable to find the repository you want to check the user's access to on the remote repository
 var ErrRepoNotFound = errors.New("Unable to find repository on remote registry")
+
+//ErrRepoNotAuthorized is the error thrown when user could not be authroized on the repository present on remote regustry with supplied credentials
+var ErrRepoNotAuthorized = errors.New("Not Authorized to access the repository")


### PR DESCRIPTION
**What this PR does / why we need it:**
Contributes to fix for [1740](https://github.com/wercker/backlog/issues/1740)

1. Comments on docker-auth.CheckAccess mention that first a basic auth request is made to docker registry - however in code nowhere did we set username/password from the config to request. Enabled this by adding a call to authenticate() which will add username/password to request so as to perform basic auth.

2. When a request is being made to docker registry using bearer token - it is possible that it can send a 401 unauthorized since the user might be "authenticated" to the registry but might not have push "authorization" on the repository in the same registry. Therefore added a check to 401 after token based request.