### PR TITLE
Upgrade azure client.

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
-//Azure - struct containing all the fields required for authentication with azure container registry
+//Azure struct containing all the fields required for authentication with azure container registry
 type Azure struct {
 	resourceGroupName string
 	registryName      string
@@ -26,7 +26,7 @@ type Azure struct {
 	dockerPassword    string
 }
 
-//NewAzure - Creates ServicePrincipleToken and a BearerAuthorizer from it and populates an Azure struct
+//NewAzure creates ServicePrincipleToken and a BearerAuthorizer from it and populates an Azure struct
 func NewAzure(clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, registryName, loginServer string) (*Azure, error) {
 	spt, err := newServicePrincipalTokenFromCredentials(clientID, clientSecret, tenantID, azure.PublicCloud.ResourceManagerEndpoint)
 	if err != nil {
@@ -45,7 +45,7 @@ func NewAzure(clientID, clientSecret, subscriptionID, tenantID, resourceGroupNam
 	}, nil
 }
 
-//CheckAccess - makes a call to Azure to get the registry information.
+//CheckAccess makes a call to Azure to get the registry information.
 // If that succeedes. check push access to registry as a standard v2 repository
 // using DockerAuth
 func (a *Azure) CheckAccess(Repository string, scope Scope) (bool, error) {
@@ -62,7 +62,7 @@ func (a *Azure) CheckAccess(Repository string, scope Scope) (bool, error) {
 
 	//Now validate push access to registry using clientId and clientSecret
 	dockerAuth := &DockerAuth{username: a.Username(), password: a.Password()}
-	regURL, err := url.Parse("https://" + a.loginServer + "/v2/")
+	regURL, err := url.Parse(fmt.Sprintf("https://%s/v2/", a.loginServer))
 	if err != nil {
 		return false, err
 	}
@@ -80,17 +80,17 @@ func (a *Azure) CheckAccess(Repository string, scope Scope) (bool, error) {
 	return true, nil
 }
 
-//Password - returns password for the registry (clientSecret)
+//Password returns password for the registry (clientSecret)
 func (a *Azure) Password() string {
 	return a.dockerPassword
 }
 
-//Username - returns username for the registry (cliendId)
+//Username returns username for the registry (cliendId)
 func (a *Azure) Username() string {
 	return a.dockerUsername
 }
 
-//Repository - returns "taggable" repository name
+//Repository returns "taggable" repository name
 func (a *Azure) Repository(repository string) string {
 	return fmt.Sprintf("%s/%s", a.loginServer, repository)
 }

--- a/azure.go
+++ b/azure.go
@@ -1,9 +1,12 @@
 package auth
 
 import (
+	"context"
 	"fmt"
-
-	"github.com/Azure/azure-sdk-for-go/arm/containerregistry"
+	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2017-10-01/containerregistry"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
@@ -11,7 +14,10 @@ type Azure struct {
 	resourceGroupName string
 	registryName      string
 	registryURL       string
+	subscriptionID    string
+	authorizer        autorest.Authorizer
 	regClient         containerregistry.RegistriesClient
+	roleClient        authorization.RoleAssignmentsClient
 	dockerUsername    string
 	dockerPassword    string
 }
@@ -23,59 +29,63 @@ func NewAzure(clientID, clientSecret, subscriptionID, tenantID, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	regClient := containerregistry.NewRegistriesClient(subscriptionID)
-	regClient.Authorizer = spt
+	authorizer := autorest.NewBearerAuthorizer(spt)
 	return &Azure{
 		resourceGroupName: resourceGroupName,
 		registryName:      registryName,
 		registryURL:       registryURL,
-		regClient:         regClient,
+		subscriptionID:    subscriptionID,
+		authorizer:        authorizer,
+		dockerUsername:    clientID,
+		dockerPassword:    clientSecret,
 	}, nil
 }
 
 func (a *Azure) CheckAccess(Repository string, scope Scope) (bool, error) {
-	res, err := a.regClient.GetCredentials(a.resourceGroupName, a.registryName)
+	regClient := containerregistry.NewRegistriesClient(a.subscriptionID)
+	regClient.Authorizer = a.authorizer
+	registry, err := regClient.Get(context.Background(), a.resourceGroupName, a.registryName)
 	if err != nil {
 		return false, err
 	}
-	a.dockerUsername = *(res.Username)
-	a.dockerPassword = *(res.Password)
-	return true, nil
+
+	roleClient := authorization.NewRoleAssignmentsClient(a.subscriptionID)
+	roleClient.Authorizer = a.authorizer
+
+	rolesIt, err := roleClient.ListForResourceComplete(context.Background(), a.resourceGroupName, "Microsoft.ContainerRegistry", *(registry.ID), *(registry.Type), *(registry.Name), "atScope()")
+	if err != nil {
+		return false, err
+	}
+
+	canAccess := false
+	for role := rolesIt.Value(); rolesIt.NotDone(); rolesIt.Next() {
+		if scope == Pull && (*(role.Name) == "Reader" || *(role.Name) == "Contributor") {
+			canAccess = true
+			break
+		} else if scope == Push && *(role.Name) == "Contributor" {
+			canAccess = true
+			break
+		}
+	}
+
+	return canAccess, nil
 }
 
 func (a *Azure) Password() string {
-	var password string
-	if a.dockerPassword == "" {
-		_, err := a.CheckAccess("", Push)
-		if err == nil {
-			password = a.dockerPassword
-		}
-	} else {
-		password = a.dockerPassword
-	}
-	return password
+	return a.dockerPassword
 }
 func (a *Azure) Username() string {
-	var username string
-	if a.dockerUsername == "" {
-		_, err := a.CheckAccess("", Push)
-		if err == nil {
-			username = a.dockerUsername
-		}
-	} else {
-		username = a.dockerUsername
-	}
-	return username
+	return a.dockerUsername
 }
 
 func (a *Azure) Repository(repository string) string {
 	return fmt.Sprintf("%s/%s", a.registryURL, repository)
 }
 
-func newServicePrincipalTokenFromCredentials(clientID, clientSecret, tenantID, scope string) (*azure.ServicePrincipalToken, error) {
-	oauthConfig, err := azure.PublicCloud.OAuthConfigForTenant(tenantID)
+func newServicePrincipalTokenFromCredentials(clientID, clientSecret, tenantID, scope string) (*adal.ServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, tenantID)
 	if err != nil {
 		return nil, err
 	}
-	return azure.NewServicePrincipalToken(*oauthConfig, clientID, clientSecret, scope)
+	return adal.NewServicePrincipalToken(*oauthConfig, clientID, clientSecret, scope)
 }

--- a/docker-auth.go
+++ b/docker-auth.go
@@ -205,7 +205,6 @@ func (d *DockerAuth) getToken(realm, service, scope string) error {
 	if d.username != "" && d.password != "" {
 		req.SetBasicAuth(d.username, d.password)
 	}
-	fmt.Println(req.Header.Get("Authorization"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err

--- a/docker-auth.go
+++ b/docker-auth.go
@@ -11,8 +11,11 @@ import (
 	"github.com/docker/distribution/reference"
 )
 
+//TokenResp - Contains access token returned from the docker registry after successful authn and authz.
+// access token field name can be either "token" or "access_token" in json returned by the registry
 type TokenResp struct {
-	Token string `json:"token"`
+	Token       string `json:"token"`
+	AccessToken string `json:"access_token"`
 }
 
 //DockerAuth implements Authenticator. It's purpose is to check whether a user has access to a Docker container by checking against a remote registry provider.
@@ -21,6 +24,14 @@ type DockerAuth struct {
 	RegistryURL *url.URL
 	username    string
 	password    string
+}
+
+//GetToken - Returns token string from TokenResp
+func (resp TokenResp) GetToken() string {
+	if resp.Token != "" {
+		return resp.Token
+	}
+	return resp.AccessToken
 }
 
 //NewDockerAuth is a constructor that takes in a remote registry url to check repository permission and basic authentication parameters for API calls to against a Docker Version 2 regisagainst a Docker Version 2 registry provider.
@@ -185,6 +196,7 @@ func (d *DockerAuth) getToken(realm, service, scope string) error {
 	}
 	encoded := v.Encode()
 	urlString := realm + "?" + encoded
+	fmt.Println(urlString)
 	req, err := http.NewRequest("GET", urlString, nil)
 	if err != nil {
 		return err
@@ -193,6 +205,7 @@ func (d *DockerAuth) getToken(realm, service, scope string) error {
 	if d.username != "" && d.password != "" {
 		req.SetBasicAuth(d.username, d.password)
 	}
+	fmt.Println(req.Header.Get("Authorization"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
@@ -201,7 +214,7 @@ func (d *DockerAuth) getToken(realm, service, scope string) error {
 
 	var T TokenResp
 	json.NewDecoder(resp.Body).Decode(&T)
-	d.token = T.Token
+	d.token = T.GetToken()
 	if d.token == "" {
 		return errors.New("Authentication failed")
 	}

--- a/docker-auth.go
+++ b/docker-auth.go
@@ -196,7 +196,6 @@ func (d *DockerAuth) getToken(realm, service, scope string) error {
 	}
 	encoded := v.Encode()
 	urlString := realm + "?" + encoded
-	fmt.Println(urlString)
 	req, err := http.NewRequest("GET", urlString, nil)
 	if err != nil {
 		return err

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 9947ba503decbbc7a93fbcd852ac9da0be6e131004f733da7a9074e4e18da2c7
-updated: 2017-08-24T16:34:32.364867187+02:00
+hash: a5918973c1b856386955685582081202c34228c2f86e7584ff2cbbbe4a4b996d
+updated: 2018-04-04T11:17:38.042457-04:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 826ec2077453adc020e9836a15fa704de931b4e6
+  version: b72688f15ec0b32551a50dceeeb2bd53f2e0d690
   subpackages:
   - aws
   - aws/awserr
@@ -20,6 +20,8 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/sdkio
+  - internal/sdkrand
   - internal/shareddefaults
   - private/protocol
   - private/protocol/json/jsonutil
@@ -32,28 +34,31 @@ imports:
   - service/iam
   - service/sts
 - name: github.com/Azure/azure-sdk-for-go
-  version: d05c22dc3f9fdd2ec6e3593839fdd44df17f2de5
+  version: 56332fec5b308fbb6615fa1af6117394cdba186d
   subpackages:
-  - arm/containerregistry
+  - services/authorization/mgmt/2015-07-01/authorization
+  - services/containerregistry/mgmt/2017-10-01/containerregistry
+  - version
 - name: github.com/Azure/go-autorest
-  version: 0c7d3adb1d6992a173eedd673f44698fe2c901be
+  version: 90128b0cbed977972cdf104474875758e9fe97d0
   subpackages:
   - autorest
+  - autorest/adal
   - autorest/azure
   - autorest/date
   - autorest/to
   - autorest/validation
 - name: github.com/dgrijalva/jwt-go
-  version: a539ee1a749a2b895533f979515ac7e6e0f5b650
+  version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - name: github.com/docker/distribution
-  version: 5f6282db7d65e6d72ad7c2cc66310724a57be716
+  version: 83389a148052d74ac602f5f1d62f86ff2f3c4aa5
   subpackages:
   - digestset
   - reference
 - name: github.com/go-ini/ini
-  version: c787282c39ac1fc618827141a1f762240def08a3
+  version: 5e9692864e22d02ac79e2fa499cffb00520b4fea
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 - name: github.com/opencontainers/go-digest
   version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
 - name: github.com/wercker/docker-reg-client

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,10 +6,11 @@ import:
   subpackages:
   - reference
 - package: github.com/Azure/azure-sdk-for-go
-  version: d05c22dc3f9fdd2ec6e3593839fdd44df17f2de5
+  version: 56332fec5b308fbb6615fa1af6117394cdba186d
   subpackages:
-  - arm/containerregistry
+  - services/containerregistry/mgmt/2017-10-01/containerregistry
+  - services/authorization/mgmt/2015-07-01/authorization
 - package: github.com/Azure/go-autorest
-  version: 0c7d3adb1d6992a173eedd673f44698fe2c901be
+  version: 90128b0cbed977972cdf104474875758e9fe97d0
   subpackages:
   - autorest/azure


### PR DESCRIPTION
This doesn't work if the user is not an admin b/c doesn't have check role permission.  One alternative is basically to make CheckAccess a no-op (which I originally did).

@lake-of-dreams - if you want to run with this, attempts to resolve wercker#1740

**Additional Changes:**

- After getting registry details is successful with clientId, clientSecret, subscriptionId and tenantId - delegate to DockerAuth.CheckAccess() to check the token based push access to repository  as is being done for other standard v2 registries
- Azure sends "access_token" instead of "token" as the field name for access token to push to the registry - Modified TokenResp struct to be able to accept both

Fixes [364](https://github.com/wercker/wercker/issues/364)