### PR TITLE
Remove CheckAccess 

### DIFF
--- a/amazon-auth.go
+++ b/amazon-auth.go
@@ -143,31 +143,6 @@ func (a AmazonAuth) Repository(repo string) string {
 	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", a.registryID, a.region, repo)
 }
 
-// CheckAccess checks to see if the current amazon user has permissions defined by scope on the given repository
-func (a *AmazonAuth) CheckAccess(Repository string, scope Scope) (bool, error) {
-	now := time.Now().Unix()
-	if a.token == "" || now > a.tokenExpire.Unix() {
-		err := a.getAuthToken()
-		if err != nil {
-			return false, err
-		}
-	}
-	if !a.strictIAM {
-		// since we we're able to get a token, we know that the user has access to the repository to a certain degree, don't parse through IAM policies and return true. will lead to false positives.
-		return true, nil
-	}
-	//check to see if the iam policys let the user access the repo
-	canAccess, err := a.getPolicyAccess(scope)
-	if err != nil {
-		return false, err
-	}
-	if canAccess {
-		return canAccess, nil
-	}
-	//if that doesnt work try looking at the resouce policy and return the results from there
-	return a.getResourceAccess(Repository, scope)
-}
-
 type PolicyText struct {
 	Version   string      `json:"Version"`
 	Statement []Statement `json:"Statement"`

--- a/authenticator.go
+++ b/authenticator.go
@@ -10,12 +10,10 @@ const (
 
 // An Authenticator is the interface that wraps the CheckAccess method
 // It implements 4 methods:
-// CheckAccess - which checks to see if a user is allowed to read and write to a certain docker repository specefied by a repository name
 // Password - which returns the password for any authenticator object, or any token an external service such as Amazon ECR or Google GCR might return to use as a password
 // Username which return the username for any authenticator object, or any defualt username an external service such as Amazon ECR or Google GCR might use
 // Repository returns the full normalized repository name
 type Authenticator interface {
-	CheckAccess(string, Scope) (bool, error)
 	Password() string
 	Username() string
 	Repository(string) string

--- a/docker-auth-v1.go
+++ b/docker-auth-v1.go
@@ -2,8 +2,6 @@ package auth
 
 import (
 	"net/url"
-
-	"github.com/wercker/docker-reg-client/registry"
 )
 
 //DockerAuthV1 implements Authenticator. It's purpose is to check whether a user has access to a Docker container by checking against a remote registry provider that still uses the Docker Version 1 registry specification.
@@ -16,39 +14,4 @@ func NewDockerAuthV1(registryURL *url.URL, username, password string) DockerAuth
 	return DockerAuthV1{
 		DockerAuth: NewDockerAuth(registryURL, username, password),
 	}
-}
-
-func (d DockerAuthV1) CheckAccess(repository string, scope Scope) (bool, error) {
-	name, err := d.normalizeRepo(repository)
-	if err != nil {
-		return false, err
-	}
-	auth := registry.BasicAuth{
-		Username: d.username,
-		Password: d.password,
-	}
-	client := registry.NewClient()
-	client.BaseURL = d.RegistryURL
-	if scope == Push {
-		_, err := client.Hub.GetWriteToken(name, auth)
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	} else if scope == Pull {
-		if d.username != "" {
-			_, err := client.Hub.GetReadTokenWithAuth(name, auth)
-			if err != nil {
-				return false, err
-			}
-			return true, nil
-		} else {
-			_, err := client.Hub.GetReadToken(name)
-			if err != nil {
-				return false, err
-			}
-			return true, nil
-		}
-	}
-	return true, nil
 }


### PR DESCRIPTION
Currently the CLI calls code in `docker-check-access` before it tries to access a docker registry.  This code implements a variety of special cases that try to determine if a user has access to a registry.  It works by making a REST call over HTTP directly to the registry.  It does *not* run on the daemon, and so does not pick up any configuration on the daemon, like certificates, insecure_registries, etc., that may actually be important.  We feel that this code should be deleted.  Not only does it not work, but also it is going to be a real pain to maintain it since we would have to be constantly implementing special cases (like artifactory docker registry support for example) and keeping them up to date. And there is really no good reason for wercker checking access when the very next command (usually a docker push) is going to do that anyway.

This PR removes the CheckAccess code, and is related to https://github.com/wercker/wercker/pull/436 in wercker/wercker which removes its use of that method.